### PR TITLE
DevelopAllow a Url style Uri to essentually ignore the trailing slash when comparing

### DIFF
--- a/Udap.UI/Pages/Shared/_Nav.cshtml
+++ b/Udap.UI/Pages/Shared/_Nav.cshtml
@@ -26,9 +26,5 @@
               </li>
             </ul>
         }
-    
-        <small class="ml-auto ">
-            &copy; 2023 Copyright: Surescripts LLC
-        </small>
     </nav>
 </div>

--- a/_tests/Udap.Client.System.Tests/udap.metadata.options.json
+++ b/_tests/Udap.Client.System.Tests/udap.metadata.options.json
@@ -1,7 +1,7 @@
 {
   "UdapMetadataConfigs": [
     {
-      "Community": "udap://fhirlabs.net",
+      "Community": "udap://fhirlabs.net/",
       "SignedMetadataConfig": {
         "Issuer": "https://fhirlabs.net:7016/fhir/r4",
         "Subject": "https://fhirlabs.net:7016/fhir/r4",

--- a/examples/Udap.Identity.Provider.2/Pages/Shared/_Nav.cshtml
+++ b/examples/Udap.Identity.Provider.2/Pages/Shared/_Nav.cshtml
@@ -27,10 +27,5 @@
               </li>
             </ul>
         }
-        
-        <small class="ml-auto text-muted">
-	        &copy; 2023 Copyright: Surescripts LLC
-        </small>
-
     </nav>
 </div>

--- a/examples/Udap.Identity.Provider/Pages/Shared/_Nav.cshtml
+++ b/examples/Udap.Identity.Provider/Pages/Shared/_Nav.cshtml
@@ -27,10 +27,5 @@
               </li>
             </ul>
         }
-    
-        <small class="ml-auto">
-	        &copy; 2023 Copyright: Surescripts LLC
-        </small>
-
     </nav>
 </div>

--- a/examples/Udap.Pki.Cli/UpdateCrlSettings.cs
+++ b/examples/Udap.Pki.Cli/UpdateCrlSettings.cs
@@ -9,6 +9,10 @@ public class UpdateCrlSettings : CommandSettings
     [Description("The type of CRL to update: CA or SubCA")]
     public CrlType Type { get; set; }
 
+    [CommandOption("--days")]
+    [Description("Set number of days before the CRL next update.")]
+    public int Days { get; set; } = 7;
+
     [CommandOption("--prod")]
     [Description("Run in production mode (default is test mode)")]
     public bool IsProduction { get; set; }

--- a/examples/Udap.Proxy.Server/Program.cs
+++ b/examples/Udap.Proxy.Server/Program.cs
@@ -13,7 +13,6 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Terminology;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
@@ -22,6 +21,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json.Serialization;
 using Firely.Fhir.Validation;
+using Microsoft.AspNetCore.Http.Json;
 using Udap.CdsHooks.Model;
 using Udap.Common;
 using Udap.Proxy.Server;
@@ -50,9 +50,9 @@ builder.Services.AddControllersWithViews();
 
 builder.Services.Configure<JsonOptions>(options =>
 {
-    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-    options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
-    options.JsonSerializerOptions.Converters.Add(new FhirResourceConverter());
+    options.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    options.SerializerOptions.PropertyNameCaseInsensitive = true;
+    options.SerializerOptions.Converters.Add(new FhirResourceConverter());
 });
 
 builder.Services.Configure<CdsServices>(builder.Configuration.GetRequiredSection("CdsServices"));

--- a/examples/clients/1_UdapClientMetadata/1_UdapClientMetadata.csproj
+++ b/examples/clients/1_UdapClientMetadata/1_UdapClientMetadata.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.24528.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.24528.1" />
-    <PackageReference Include="Udap.Client" Version="0.5.1" />
+    <PackageReference Include="Udap.Client" Version="0.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/clients/2_UdapClientMetadata/2_UdapClientMetadata.csproj
+++ b/examples/clients/2_UdapClientMetadata/2_UdapClientMetadata.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.24528.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.24528.1" />
-    <PackageReference Include="Udap.Client" Version="0.5.1" />
+    <PackageReference Include="Udap.Client" Version="0.5.5" />
   </ItemGroup>
  
   <ItemGroup>


### PR DESCRIPTION
These two URIs would be considered the same:

https://dev-mtx-interop.meditech.com/
https://dev-mtx-interop.meditech.com/

This shows up when encoding a sub-alt-name is a certificate as
https://dev-mtx-interop.meditech.com/
But the iss is set to https://dev-mtx-interop.meditech.com/

With this change the two will still validate as the same.


Minor nit.
Just set UdapCertificationsRequired to null if there are no UdapCertificationsSupported.
Also found that Json ignoring of null on serialization was not happing as expected.